### PR TITLE
Change the default schema from 'alter' to 'safe'

### DIFF
--- a/lib/waterline-schema/attributes.js
+++ b/lib/waterline-schema/attributes.js
@@ -101,7 +101,7 @@ Attributes.prototype.setDefaults = function(collection, defaults) {
     autoPK: true,
     autoCreatedAt: true,
     autoUpdatedAt: true,
-    migrate: 'alter'
+    migrate: 'safe',
   };
 
   // Override default settings with user defined defaults


### PR DESCRIPTION
Alter is dangerous and means that all of our tables can be dropped if somehow
we load Sails without specifying the `migrate` setting and without setting
NODE_ENV to 'production'.
